### PR TITLE
special case crash fix

### DIFF
--- a/library/src/main/java/com/cookieinformation/mobileconsents/storage/ConsentStorage.kt
+++ b/library/src/main/java/com/cookieinformation/mobileconsents/storage/ConsentStorage.kt
@@ -143,6 +143,17 @@ internal class ConsentStorage(
     Type.findTypeByValue(it.value as String)
   }
 
+  /**
+   * Save consent types
+   */
+  fun saveConsentTypes(types: Map<UUID, Type>) {
+    val editor = consentPreferences.consentsTypePreferences().edit()
+    types.forEach {
+      editor.putString(it.key.toString(), it.value.typeName)
+    }
+    editor.commit()
+  }
+
 
   /**
    * Maps key and value read from file to consents map

--- a/scripts/publish-module.gradle
+++ b/scripts/publish-module.gradle
@@ -25,7 +25,7 @@ afterEvaluate {
                 // we'll set up later
                 groupId 'com.cookieinformation'
                 artifactId 'mobileconsents'
-                version '1.0.13'
+                version '1.0.14'
 
                 // Two artifacts, the `aar` (or `jar`) and the sources
                 if (project.plugins.findPlugin("com.android.library")) {


### PR DESCRIPTION
- fixed the crash in getSavedConsentsWithType due missing locally saved consent types in case when the function is called before displayConsents or displayConsentsIfNeeded

[JIRA Task](https://droidsonroids.atlassian.net/browse/CLEAR-)
[External code review, CLEAR-2](https://droidsonroids.atlassian.net/browse/CLEAR-2)
