### PR TITLE
Release 2.0.7

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -79,6 +79,11 @@
       <option name="JD_PRESERVE_LINE_FEEDS" value="true" />
     </JavaCodeStyleSettings>
     <JetCodeStyleSettings>
+      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
+        <value />
+      </option>
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="IMPORT_NESTED_CLASSES" value="true" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -79,11 +79,6 @@
       <option name="JD_PRESERVE_LINE_FEEDS" value="true" />
     </JavaCodeStyleSettings>
     <JetCodeStyleSettings>
-      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
-        <value />
-      </option>
-      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
-      <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="IMPORT_NESTED_CLASSES" value="true" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>

--- a/javasample/src/main/java/com/hanna/test/cookieinformation/javasample/MyApplication.java
+++ b/javasample/src/main/java/com/hanna/test/cookieinformation/javasample/MyApplication.java
@@ -20,14 +20,15 @@ import com.cookieinformation.mobileconsents.models.SdkTextStyle;
 import com.cookieinformation.mobileconsents.models.SubtitleStyle;
 import com.cookieinformation.mobileconsents.models.TitleStyle;
 import com.cookieinformation.mobileconsents.storage.ConsentWithType;
+import com.cookieinformation.mobileconsents.ui.LabelText;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
 import java.util.UUID;
-import kotlin.ParameterName;
 import kotlin.Unit;
 import kotlin.coroutines.Continuation;
 import kotlin.jvm.functions.Function2;
@@ -35,89 +36,109 @@ import kotlinx.coroutines.Dispatchers;
 
 public class MyApplication extends Application implements Consentable {
 
-    @Override public void onCreate() {
-        super.onCreate();
-        getSdk().initSDKWithCompletion(new Function2<Boolean, IOException, Unit>() {
-            @Override public Unit invoke(Boolean aBoolean, IOException e) {
-                return null;
-            }
-        });
-    }
+  @Override public void onCreate() {
+    super.onCreate();
 
-    @Override public void initSDKWithCompletion(
-        @NonNull Function2<? super Boolean, ? super IOException, Unit> onComplete
-    ) {
-        getSdk().initSDKWithCompletion(onComplete);
-    }
+    getSdk().initSDKWithCompletion(new Function2<Boolean, IOException, Unit>() {
+      @Override public Unit invoke(Boolean aBoolean, IOException e) {
+        return null;
+      }
+    });
+  }
 
-    @Nullable @Override public Object initSDK(@NonNull Continuation<? super Unit> $completion) {
-        return getSdk().initSDK($completion);
-    }
+  @Override public void initSDKWithCompletion(
+      @NonNull Function2<? super Boolean, ? super IOException, Unit> onComplete
+  ) {
+    getSdk().initSDKWithCompletion(onComplete);
+  }
 
-    @NonNull
-    @Override
-    public MobileConsents getSdk() {
-        return new MobileConsents(provideConsentSdk(), Dispatchers.getMain());
-    }
+  @Nullable @Override public Object initSDK(@NonNull Continuation<? super Unit> $completion) {
+    return getSdk().initSDK($completion);
+  }
 
-    @Nullable
-    @Override
-    public Object getSavedConsents(@NonNull Continuation<? super Map<UUID, Boolean>> continuation) {
-        return getSdk().getSavedConsents(new CallListener<Map<UUID, Boolean>>() {
-            @Override
-            public void onSuccess(Map<UUID, Boolean> typeBooleanMap) {
+  @NonNull
+  @Override
+  public MobileConsents getSdk() {
+    return new MobileConsents(provideConsentSdk(), Dispatchers.getMain());
+  }
 
-            }
+  @Nullable
+  @Override
+  public Object getSavedConsents(@NonNull Continuation<? super Map<UUID, Boolean>> continuation) {
+    return getSdk().getSavedConsents(new CallListener<Map<UUID, Boolean>>() {
+      @Override
+      public void onSuccess(Map<UUID, Boolean> typeBooleanMap) {
 
-            @Override
-            public void onFailure(@NonNull IOException e) {
+      }
 
-            }
-        });
-    }
+      @Override
+      public void onFailure(@NonNull IOException e) {
 
-    @Nullable
-    @Override
-    public Object getSavedConsentsWithType(@NonNull Continuation<? super Map<UUID, ConsentWithType>> continuation) {
-        return getSdk().getSavedConsentsWithType(new CallListener<Map<UUID, ConsentWithType>>() {
-            @Override
-            public void onSuccess(Map<UUID, ConsentWithType> typeBooleanMap) {
+      }
+    });
+  }
 
-            }
+  @Nullable
+  @Override
+  public Object getSavedConsentsWithType(@NonNull Continuation<? super Map<UUID, ConsentWithType>> continuation) {
+    return getSdk().getSavedConsentsWithType(new CallListener<Map<UUID, ConsentWithType>>() {
+      @Override
+      public void onSuccess(Map<UUID, ConsentWithType> typeBooleanMap) {
 
-            @Override
-            public void onFailure(@NonNull IOException e) {
+      }
 
-            }
-        });
-    }
+      @Override
+      public void onFailure(@NonNull IOException e) {
 
-    @NonNull
-    @Override
-    public MobileConsentSdk provideConsentSdk() {
-        List<Locale> localList = new ArrayList();
-        localList.add(new Locale("EN"));
-        localList.add(Locale.FRENCH);
-        return MobileConsentSdk.Builder(this)
-            .setClientCredentials(provideCredentials())
-            .setMobileConsentCustomUI(
-                new MobileConsentCustomUI(Color.parseColor("#ff0000"),
-                    new SdkTextStyle(
+      }
+    });
+  }
+
+  @NonNull
+  @Override
+  public MobileConsentSdk provideConsentSdk() {
+    List<Locale> localList = new ArrayList();
+    localList.add(new Locale("FR"));
+    localList.add(Locale.FRENCH);
+    return MobileConsentSdk.Builder(this)
+        .setClientCredentials(provideCredentials())
+        .setMobileConsentCustomUI(
+            new MobileConsentCustomUI(
+                Color.parseColor("#ff0000"),
+                new SdkTextStyle(
                     new TitleStyle(null),
                     new SubtitleStyle(Typeface.MONOSPACE),
                     new BodyStyle(null)
-                )))
-            .setLanguages(localList)
-            .build();
-    }
+                )
+            ))
+        .setLanguages(localList)
+        .setLocalizationOverride(fetchOverridenLocalization())
+        .build();
+  }
 
-    @NonNull
-    @Override
-    public MobileConsentCredentials provideCredentials() {
-        return new MobileConsentCredentials(
-            "40dbe5a7-1c01-463a-bb08-a76970c0efa0",
-            "68cbf024407a20b8df4aecc3d9937f43c6e83169dafcb38b8d18296b515cc0d5f8bca8165d615caa4d12e236192851e9c5852a07319428562af8f920293bc1db",
-            "4113ab88-4980-4429-b2d1-3454cc81197b"
-        );
-    }
+  private Map<Locale, LabelText> fetchOverridenLocalization() {
+    Map<Locale, LabelText> map = new HashMap<>();
+    map.put(Locale.FRENCH, new LabelText(
+        "titleFrench",
+        "acceptAllButtonTitleFrench",
+        "saveSelectionButtonTitleFrench",
+        "privacyDescriptionFrench",
+        "privacyPolicyLongtextFrench",
+        "readMoreButtonFrench",
+        "requiredSectionHeaderFrench",
+        "optionalSectionHeaderFrench",
+        "readMoreScreenHeaderFrench"
+    ));
+    return map;
+  }
+
+  @NonNull
+  @Override
+  public MobileConsentCredentials provideCredentials() {
+    return new MobileConsentCredentials(
+        "40dbe5a7-1c01-463a-bb08-a76970c0efa0",
+        "68cbf024407a20b8df4aecc3d9937f43c6e83169dafcb38b8d18296b515cc0d5f8bca8165d615caa4d12e236192851e9c5852a07319428562af8f920293bc1db",
+        "4113ab88-4980-4429-b2d1-3454cc81197b"
+    );
+  }
 }

--- a/library/src/main/java/com/cookieinformation/mobileconsents/MobileConsentSdk.kt
+++ b/library/src/main/java/com/cookieinformation/mobileconsents/MobileConsentSdk.kt
@@ -16,12 +16,14 @@ import com.cookieinformation.mobileconsents.networking.response.toDomain
 import com.cookieinformation.mobileconsents.storage.ConsentStorage
 import com.cookieinformation.mobileconsents.storage.ConsentWithType
 import com.cookieinformation.mobileconsents.system.ApplicationProperties
+import com.cookieinformation.mobileconsents.ui.LabelText
 import com.cookieinformation.mobileconsents.ui.base.BaseConsentsView
 import com.cookieinformation.mobileconsents.ui.LocaleProvider
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.withContext
 import java.io.IOException
+import java.util.Locale
 import java.util.UUID
 
 /**
@@ -43,6 +45,7 @@ public class MobileConsentSdk internal constructor(
   public val saveConsentsFlow: SharedFlow<Map<UUID, Boolean>>,
   private val uiComponentColor: MobileConsentCustomUI?,
   private val uiLanguageCode: LocaleProvider,
+  private var localizationOverride: Map<Locale, LabelText>? = null,
   private val consentsView: BaseConsentsView?
 ) {
 
@@ -51,6 +54,7 @@ public class MobileConsentSdk internal constructor(
   public fun getConsentSolutionId(): String = consentClient.consentSolutionId.toString()
   public fun getUiComponentColor(): MobileConsentCustomUI? = uiComponentColor
   public fun uiLanguageProvider(): LocaleProvider = uiLanguageCode
+  public fun localizationOverride(): Map<Locale, LabelText>? = localizationOverride
   public fun getConsentsView(): BaseConsentsView? = consentsView
 
   public suspend fun init() {

--- a/library/src/main/java/com/cookieinformation/mobileconsents/MobileConsentSdkBuilder.kt
+++ b/library/src/main/java/com/cookieinformation/mobileconsents/MobileConsentSdkBuilder.kt
@@ -16,6 +16,7 @@ import com.cookieinformation.mobileconsents.storage.Preferences
 import com.cookieinformation.mobileconsents.system.getApplicationProperties
 import com.cookieinformation.mobileconsents.ui.base.BaseConsentsView
 import com.cookieinformation.mobileconsents.ui.DefaultLocaleProvider
+import com.cookieinformation.mobileconsents.ui.LabelText
 import com.cookieinformation.mobileconsents.ui.LocaleProvider
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -41,6 +42,7 @@ internal class MobileConsentSdkBuilder constructor(
   private var clientSecret: String? = null
   private var customColor: MobileConsentCustomUI? = null
   private var sdkLocale: LocaleProvider? = null
+  private var localizationOverride: Map<Locale, LabelText>? = null
   private var customConsentView: BaseConsentsView? = null
 
   override fun setCustomConsentView(view: BaseConsentsView?): CallFactory {
@@ -66,6 +68,11 @@ internal class MobileConsentSdkBuilder constructor(
         return locales
       }
     }
+    return this
+  }
+
+  override fun setLocalizationOverride(localizationOverride: Map<Locale, LabelText>?): CallFactory {
+    this.localizationOverride = localizationOverride
     return this
   }
 
@@ -123,6 +130,7 @@ internal class MobileConsentSdkBuilder constructor(
       saveConsentsFlow = consentStorage.saveConsentsFlow,
       uiComponentColor = customColor,
       uiLanguageCode = sdkLocale ?: DefaultLocaleProvider(context.applicationContext),
+      localizationOverride = localizationOverride,
       consentsView =  customConsentView
     )
   }

--- a/library/src/main/java/com/cookieinformation/mobileconsents/UiTexts.kt
+++ b/library/src/main/java/com/cookieinformation/mobileconsents/UiTexts.kt
@@ -28,5 +28,9 @@ public data class UiTexts(
   val privacyCenterTitle: List<TextTranslation>,
 
   val poweredByLabel: List<TextTranslation>,
-  val consentPreferencesLabel: List<TextTranslation>
+  val consentPreferencesLabel: List<TextTranslation>,
+
+  val requiredTableSectionHeader: List<TextTranslation>,
+  val optionalTableSectionHeader: List<TextTranslation>,
+  val readMoreScreenHeader: List<TextTranslation>,
 )

--- a/library/src/main/java/com/cookieinformation/mobileconsents/interfaces/CallFactory.kt
+++ b/library/src/main/java/com/cookieinformation/mobileconsents/interfaces/CallFactory.kt
@@ -3,6 +3,7 @@ package com.cookieinformation.mobileconsents.interfaces
 import com.cookieinformation.mobileconsents.MobileConsentSdk
 import com.cookieinformation.mobileconsents.models.MobileConsentCredentials
 import com.cookieinformation.mobileconsents.models.MobileConsentCustomUI
+import com.cookieinformation.mobileconsents.ui.LabelText
 import com.cookieinformation.mobileconsents.ui.base.BaseConsentsView
 import java.util.Locale
 
@@ -12,7 +13,8 @@ import java.util.Locale
 public interface CallFactory {
   public fun setClientCredentials(credentials: MobileConsentCredentials): CallFactory
   public fun setMobileConsentCustomUI(customUI: MobileConsentCustomUI): CallFactory
-  public fun setLanguages(locales: List<Locale> = listOf( Locale.getDefault())): CallFactory
+  public fun setLanguages(locales: List<Locale> = listOf(Locale.getDefault())): CallFactory
+  public fun setLocalizationOverride(localizationOverride: Map<Locale, LabelText>?): CallFactory
   public fun setCustomConsentView(view: BaseConsentsView?): CallFactory
   public fun build(): MobileConsentSdk
 }

--- a/library/src/main/java/com/cookieinformation/mobileconsents/networking/response/ConsentSolutionResponse.kt
+++ b/library/src/main/java/com/cookieinformation/mobileconsents/networking/response/ConsentSolutionResponse.kt
@@ -1,6 +1,5 @@
 package com.cookieinformation.mobileconsents.networking.response
 
-import android.util.Log
 import com.cookieinformation.mobileconsents.ConsentSolution
 import com.cookieinformation.mobileconsents.UiTexts
 import com.squareup.moshi.Json

--- a/library/src/main/java/com/cookieinformation/mobileconsents/networking/response/ConsentSolutionResponse.kt
+++ b/library/src/main/java/com/cookieinformation/mobileconsents/networking/response/ConsentSolutionResponse.kt
@@ -30,6 +30,9 @@ internal fun ConsentSolutionResponse.toDomainUiTexts() =
     privacyCenterTitle = templateTexts.privacyCenterTitle.map(TextTranslationResponse::toDomain),
     poweredByLabel = templateTexts.poweredByCoiLabel.map(TextTranslationResponse::toDomain),
     consentPreferencesLabel = templateTexts.consentPreferencesLabel.map(TextTranslationResponse::toDomain),
+    requiredTableSectionHeader = templateTexts.requiredTableSectionHeader?.map(TextTranslationResponse::toDomain).orEmpty(),
+    optionalTableSectionHeader = templateTexts.optionalTableSectionHeader?.map(TextTranslationResponse::toDomain).orEmpty(),
+    readMoreScreenHeader = templateTexts.readMoreScreenHeader?.map(TextTranslationResponse::toDomain).orEmpty(),
   )
 
 internal fun ConsentSolutionResponse.toDomain(): ConsentSolution {

--- a/library/src/main/java/com/cookieinformation/mobileconsents/networking/response/TemplateTextsResponse.kt
+++ b/library/src/main/java/com/cookieinformation/mobileconsents/networking/response/TemplateTextsResponse.kt
@@ -13,5 +13,8 @@ internal data class TemplateTextsResponse(
   @Json(name = "privacyPreferencesTabLabel") val privacyPreferencesTabLabel: List<TextTranslationResponse>,
   @Json(name = "privacyCenterButton") val privacyCenterButton: List<TextTranslationResponse>,
   @Json(name = "poweredByCoiLabel") val poweredByCoiLabel: List<TextTranslationResponse>,
-  @Json(name = "consentPreferencesLabel") val consentPreferencesLabel: List<TextTranslationResponse>
+  @Json(name = "consentPreferencesLabel") val consentPreferencesLabel: List<TextTranslationResponse>,
+  @Json(name = "requiredTableSectionHeader") val requiredTableSectionHeader: List<TextTranslationResponse>?,
+  @Json(name = "optionalTableSectionHeader") val optionalTableSectionHeader: List<TextTranslationResponse>?,
+  @Json(name = "readMoreScreenHeader") val readMoreScreenHeader: List<TextTranslationResponse>?
 )

--- a/library/src/main/java/com/cookieinformation/mobileconsents/ui/ConsentSolutionPresenter.kt
+++ b/library/src/main/java/com/cookieinformation/mobileconsents/ui/ConsentSolutionPresenter.kt
@@ -1,11 +1,9 @@
 package com.cookieinformation.mobileconsents.ui
 
 import android.content.Context
-import android.util.Log
 import androidx.annotation.MainThread
 import com.cookieinformation.mobileconsents.Consent
 import com.cookieinformation.mobileconsents.ConsentItem
-import com.cookieinformation.mobileconsents.ConsentItem.Type
 import com.cookieinformation.mobileconsents.ConsentSolution
 import com.cookieinformation.mobileconsents.MobileConsentSdk
 import com.cookieinformation.mobileconsents.ProcessingPurpose

--- a/library/src/main/java/com/cookieinformation/mobileconsents/ui/ConsentSolutionPresenter.kt
+++ b/library/src/main/java/com/cookieinformation/mobileconsents/ui/ConsentSolutionPresenter.kt
@@ -69,7 +69,7 @@ internal abstract class ConsentSolutionPresenter<ViewType, ViewDataType, ViewInt
   private lateinit var consentSdk: MobileConsentSdk
   private lateinit var localeProvider: LocaleProvider
   private lateinit var preferences: Preferences
-  private val locales: List<Locale>
+  protected val locales: List<Locale>
     get() = localeProvider.getLocales()
 
   protected var listener: ConsentSolutionListener? = null
@@ -258,7 +258,7 @@ internal abstract class ConsentSolutionPresenter<ViewType, ViewDataType, ViewInt
       try {
         viewState = ViewState.Fetching
         val consentSolution = consentSdk.fetchConsentSolution()
-        viewState = ViewState.Fetched(createViewData(consentSolution, consentSdk.getSavedConsents()), consentSolution)
+        viewState = ViewState.Fetched(createViewData(consentSolution, consentSdk.getSavedConsents(), consentSdk.localizationOverride()), consentSolution)
       } catch (_: IOException) {
         viewState = ViewState.FetchError
       }
@@ -348,7 +348,8 @@ internal abstract class ConsentSolutionPresenter<ViewType, ViewDataType, ViewInt
 
   protected abstract fun createViewData(
     consentSolution: ConsentSolution,
-    savedConsents: Map<UUID, Boolean>
+    savedConsents: Map<UUID, Boolean>,
+    localizationOverride: Map<Locale, LabelText>?,
   ): ViewDataType
 
   protected abstract fun getGivenConsents(viewData: ViewDataType): GivenConsent

--- a/library/src/main/java/com/cookieinformation/mobileconsents/ui/LabelText.kt
+++ b/library/src/main/java/com/cookieinformation/mobileconsents/ui/LabelText.kt
@@ -1,0 +1,13 @@
+package com.cookieinformation.mobileconsents.ui
+
+public data class LabelText(
+  val title: String? = null,
+  val acceptAllButtonTitle: String? = null,
+  val saveSelectionButtonTitle: String? = null,
+  val privacyDescription: String? = null,
+  val privacyPolicyLongtext: String? = null,
+  val readMoreButton: String? = null,
+  val requiredSectionHeader: String? = null,
+  val optionalSectionHeader: String? = null,
+  val readMoreScreenHeader: String? = null
+)

--- a/library/src/main/java/com/cookieinformation/mobileconsents/ui/PrivacyFragment.kt
+++ b/library/src/main/java/com/cookieinformation/mobileconsents/ui/PrivacyFragment.kt
@@ -1,7 +1,6 @@
 package com.cookieinformation.mobileconsents.ui
 
 import android.content.Intent
-import android.content.pm.ActivityInfo
 import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -13,7 +12,6 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
 import com.cookieinformation.mobileconsents.ConsentSolution
 import com.cookieinformation.mobileconsents.Consentable
-import com.cookieinformation.mobileconsents.R
 import com.cookieinformation.mobileconsents.models.SdkTextStyle
 import com.cookieinformation.mobileconsents.ui.ConsentSolutionViewModel.Event
 import com.cookieinformation.mobileconsents.ui.base.BaseConsentsView
@@ -68,11 +66,6 @@ internal class PrivacyFragment : BasePrivacyFragment() {
       .onEach(::handleEvent)
       .launchIn(viewLifecycleOwner.lifecycleScope)
     viewModel.attachView(view as BaseConsentsView)
-    val isTablet = resources.getBoolean(R.bool.isTablet)
-    if (!isTablet) {
-      // Force the fragments in portrait mode if app is running on a smartphone, since there is only one layout
-      activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-    }
   }
 
   /**
@@ -80,8 +73,6 @@ internal class PrivacyFragment : BasePrivacyFragment() {
    */
   @CallSuper
   override fun onDestroyView() {
-    // Set the orientation as unspecified no matter what, then fragment is destroyed
-    activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
     viewModel.detachView()
     super.onDestroyView()
   }

--- a/library/src/main/java/com/cookieinformation/mobileconsents/ui/PrivacyFragmentListAdapter.kt
+++ b/library/src/main/java/com/cookieinformation/mobileconsents/ui/PrivacyFragmentListAdapter.kt
@@ -21,6 +21,9 @@ internal class PrivacyFragmentListAdapter(
 ) :
   ListAdapter<PrivacyFragmentPreferencesItem, PrivacyFragmentListAdapter.ItemViewHolder>(AdapterConsentItemDiffCallback()) {
 
+  private var requiredHeader: String? = null
+  private var optionalHeader: String? = null
+
   override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) =
     PreferencesItemViewHolder(
       LayoutInflater.from(parent.context)
@@ -28,13 +31,21 @@ internal class PrivacyFragmentListAdapter(
       onConsentItemChoiceToggle, sdkColor, sdkTextStyle
     )
 
-  override fun onBindViewHolder(holder: ItemViewHolder, position: Int) = holder.bind(getItem(position))
+  override fun onBindViewHolder(holder: ItemViewHolder, position: Int) =
+    holder.bind(getItem(position), requiredHeader, optionalHeader)
 
-  abstract class ItemViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
-    abstract fun bind(item: PrivacyFragmentPreferencesItem)
+  fun submitList(list: List<PrivacyFragmentPreferencesItem>?, requiredTitle: String?, optionalTitle: String?) {
+    this.requiredHeader = requiredTitle
+    this.optionalHeader = optionalTitle
+    super.submitList(list)
   }
 
-  class PreferencesItemViewHolder(itemView: View, onConsentItemChoiceToggle: (UUID, Boolean) -> Unit,
+  abstract class ItemViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+    abstract fun bind(item: PrivacyFragmentPreferencesItem, requiredTitle: String?, optionalTitle: String?)
+  }
+
+  inner class PreferencesItemViewHolder(
+    itemView: View, onConsentItemChoiceToggle: (UUID, Boolean) -> Unit,
     sdkColor: Int?,
     sdkTextStyle: SdkTextStyle?,
   ) :
@@ -50,18 +61,24 @@ internal class PrivacyFragmentListAdapter(
       }
     }
 
-    override fun bind(item: PrivacyFragmentPreferencesItem) {
-      val groups = item.items.filter { it.type!= Type.Info }.groupBy { it.required }
+    override fun bind(item: PrivacyFragmentPreferencesItem, requiredTitle: String?, optionalTitle: String?) {
+      val groups = item.items.filter { it.type != Type.Info }.groupBy { it.required }
       val finalList = mutableListOf<ItemizedPreference>().apply {
         groups[true]?.let {
           add(
             0,
-            PrivacyPreferencesItemHeader(itemView.context.getString(R.string.mobileconsents_required_privacy_consents_title))
+            PrivacyPreferencesItemHeader(
+              if (requiredTitle.orEmpty().isNotEmpty()) requiredTitle!! else itemView.context.getString(R.string.mobileconsents_required_privacy_consents_title)
+            )
           )
           addAll(it)
         }
         groups[false]?.let {
-          add(PrivacyPreferencesItemHeader(itemView.context.getString(R.string.mobileconsents_optional_privacy_consents_title)))
+          add(
+            PrivacyPreferencesItemHeader(
+              if(optionalTitle.orEmpty().isNotEmpty()) optionalTitle!! else itemView.context.getString(R.string.mobileconsents_optional_privacy_consents_title)
+            )
+          )
           addAll(it)
         }
       }

--- a/library/src/main/java/com/cookieinformation/mobileconsents/ui/PrivacyFragmentListAdapter.kt
+++ b/library/src/main/java/com/cookieinformation/mobileconsents/ui/PrivacyFragmentListAdapter.kt
@@ -67,17 +67,13 @@ internal class PrivacyFragmentListAdapter(
         groups[true]?.let {
           add(
             0,
-            PrivacyPreferencesItemHeader(
-              requiredTitle.ifEmpty { itemView.context.getString(R.string.mobileconsents_required_privacy_consents_title) }
-            )
+            PrivacyPreferencesItemHeader(requiredTitle)
           )
           addAll(it)
         }
         groups[false]?.let {
           add(
-            PrivacyPreferencesItemHeader(
-              optionalTitle.ifEmpty { itemView.context.getString(R.string.mobileconsents_optional_privacy_consents_title) }
-            )
+            PrivacyPreferencesItemHeader(optionalTitle)
           )
           addAll(it)
         }

--- a/library/src/main/java/com/cookieinformation/mobileconsents/ui/PrivacyFragmentListAdapter.kt
+++ b/library/src/main/java/com/cookieinformation/mobileconsents/ui/PrivacyFragmentListAdapter.kt
@@ -21,8 +21,8 @@ internal class PrivacyFragmentListAdapter(
 ) :
   ListAdapter<PrivacyFragmentPreferencesItem, PrivacyFragmentListAdapter.ItemViewHolder>(AdapterConsentItemDiffCallback()) {
 
-  private var requiredHeader: String? = null
-  private var optionalHeader: String? = null
+  private var requiredHeader: String = ""
+  private var optionalHeader: String = ""
 
   override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) =
     PreferencesItemViewHolder(
@@ -34,14 +34,14 @@ internal class PrivacyFragmentListAdapter(
   override fun onBindViewHolder(holder: ItemViewHolder, position: Int) =
     holder.bind(getItem(position), requiredHeader, optionalHeader)
 
-  fun submitList(list: List<PrivacyFragmentPreferencesItem>?, requiredTitle: String?, optionalTitle: String?) {
+  fun submitList(list: List<PrivacyFragmentPreferencesItem>, requiredTitle: String, optionalTitle: String) {
     this.requiredHeader = requiredTitle
     this.optionalHeader = optionalTitle
     super.submitList(list)
   }
 
   abstract class ItemViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
-    abstract fun bind(item: PrivacyFragmentPreferencesItem, requiredTitle: String?, optionalTitle: String?)
+    abstract fun bind(item: PrivacyFragmentPreferencesItem, requiredTitle: String, optionalTitle: String)
   }
 
   inner class PreferencesItemViewHolder(
@@ -61,14 +61,14 @@ internal class PrivacyFragmentListAdapter(
       }
     }
 
-    override fun bind(item: PrivacyFragmentPreferencesItem, requiredTitle: String?, optionalTitle: String?) {
+    override fun bind(item: PrivacyFragmentPreferencesItem, requiredTitle: String, optionalTitle: String) {
       val groups = item.items.filter { it.type != Type.Info }.groupBy { it.required }
       val finalList = mutableListOf<ItemizedPreference>().apply {
         groups[true]?.let {
           add(
             0,
             PrivacyPreferencesItemHeader(
-              if (requiredTitle.orEmpty().isNotEmpty()) requiredTitle!! else itemView.context.getString(R.string.mobileconsents_required_privacy_consents_title)
+              requiredTitle.ifEmpty { itemView.context.getString(R.string.mobileconsents_required_privacy_consents_title) }
             )
           )
           addAll(it)
@@ -76,7 +76,7 @@ internal class PrivacyFragmentListAdapter(
         groups[false]?.let {
           add(
             PrivacyPreferencesItemHeader(
-              if(optionalTitle.orEmpty().isNotEmpty()) optionalTitle!! else itemView.context.getString(R.string.mobileconsents_optional_privacy_consents_title)
+              optionalTitle.ifEmpty { itemView.context.getString(R.string.mobileconsents_optional_privacy_consents_title) }
             )
           )
           addAll(it)

--- a/library/src/main/java/com/cookieinformation/mobileconsents/ui/PrivacyFragmentPresenter.kt
+++ b/library/src/main/java/com/cookieinformation/mobileconsents/ui/PrivacyFragmentPresenter.kt
@@ -158,7 +158,7 @@ internal class PrivacyFragmentPresenter(
     val items = mutableListOf<PrivacyFragmentPreferencesItem>()
     items.add(preferencesItem)
 
-    val code = localizationOverride?.keys?.first { it in locales }
+    val code = localizationOverride?.keys?.firstOrNull { it in locales }
     val overridenTranslations: LabelText? = localizationOverride?.get(code)
 
     val poweredByLabelTranslation = uiTexts.poweredByLabel.translate()

--- a/library/src/main/java/com/cookieinformation/mobileconsents/ui/PrivacyFragmentPresenter.kt
+++ b/library/src/main/java/com/cookieinformation/mobileconsents/ui/PrivacyFragmentPresenter.kt
@@ -1,6 +1,5 @@
 package com.cookieinformation.mobileconsents.ui
 
-import android.util.Log
 import com.cookieinformation.mobileconsents.ConsentItem.Type.Info
 import com.cookieinformation.mobileconsents.ConsentSolution
 import com.cookieinformation.mobileconsents.UiTexts

--- a/library/src/main/java/com/cookieinformation/mobileconsents/ui/PrivacyFragmentPresenter.kt
+++ b/library/src/main/java/com/cookieinformation/mobileconsents/ui/PrivacyFragmentPresenter.kt
@@ -165,6 +165,9 @@ internal class PrivacyFragmentPresenter(
       acceptSelectedButtonEnabled = areAllRequiredAccepted(preferencesItem.items),
       acceptAllButtonText = uiTexts.acceptAllButton.translate().text,
       poweredByLabelText = "<a href=\"$cookieInformationUrl\">${poweredByLabelTranslation.text}</a>",
+      requiredTableSectionHeader = uiTexts.requiredTableSectionHeader.translate().text,
+      optionalTableSectionHeader = uiTexts.optionalTableSectionHeader.translate().text,
+      readMoreScreenHeader = uiTexts.readMoreScreenHeader.translate().text,
       items = items
     )
   }

--- a/library/src/main/java/com/cookieinformation/mobileconsents/ui/PrivacyFragmentView.kt
+++ b/library/src/main/java/com/cookieinformation/mobileconsents/ui/PrivacyFragmentView.kt
@@ -16,6 +16,7 @@ import com.cookieinformation.mobileconsents.R
 import com.cookieinformation.mobileconsents.models.SdkTextStyle
 import com.cookieinformation.mobileconsents.ui.base.BaseConsentsView
 import com.cookieinformation.mobileconsents.util.setTextFromHtml
+import java.util.Locale
 
 /**
  * The Privacy view implementation. The view is used in [BasePrivacyFragment] and should not be used directly

--- a/library/src/main/java/com/cookieinformation/mobileconsents/ui/PrivacyFragmentView.kt
+++ b/library/src/main/java/com/cookieinformation/mobileconsents/ui/PrivacyFragmentView.kt
@@ -1,6 +1,5 @@
 package com.cookieinformation.mobileconsents.ui
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.PorterDuff
 import android.util.AttributeSet
@@ -146,7 +145,7 @@ public class PrivacyFragmentView @JvmOverloads constructor(
       setTextFromHtml(data.poweredByLabelText, boldLinks = false, underline = true)
     }
 
-    consentListAdapter.submitList(data.items)
+    consentListAdapter.submitList(data.items, data.requiredTableSectionHeader, data.optionalTableSectionHeader)
     showContentViewData()
   }
 

--- a/library/src/main/java/com/cookieinformation/mobileconsents/ui/PrivacyFragmentViewData.kt
+++ b/library/src/main/java/com/cookieinformation/mobileconsents/ui/PrivacyFragmentViewData.kt
@@ -12,5 +12,8 @@ public data class PrivacyFragmentViewData(
   val acceptSelectedButtonEnabled: Boolean,
   val acceptAllButtonText: String,
   val poweredByLabelText: String,
+  val requiredTableSectionHeader: String,
+  val optionalTableSectionHeader: String,
+  val readMoreScreenHeader: String,
   val items: List<PrivacyFragmentPreferencesItem>,
 )

--- a/library/src/main/java/com/cookieinformation/mobileconsents/ui/PrivacyPreferencesListAdapter.kt
+++ b/library/src/main/java/com/cookieinformation/mobileconsents/ui/PrivacyPreferencesListAdapter.kt
@@ -132,6 +132,7 @@ public class PreferenceItemViewHolder(
     }
     consentSwitch.apply {
       isChecked = data.accepted || data.required
+      contentDescription = data.text
       if (data.required) {
         onConsentItemChanged(data.id, isChecked)
       }

--- a/scripts/publish-module.gradle
+++ b/scripts/publish-module.gradle
@@ -25,7 +25,7 @@ afterEvaluate {
                 // we'll set up later
                 groupId 'com.cookieinformation'
                 artifactId 'mobileconsents'
-                version '2.0.6'
+                version '2.0.7'
 
                 // Two artifacts, the `aar` (or `jar`) and the sources
                 if (project.plugins.findPlugin("com.android.library")) {


### PR DESCRIPTION
This pr is handling the following 3 things:
- Removed the forced portrait orientation
- Added new translation fields to the networking layer. These fields are optional and will therefore fall back to their default values if null.
- Added data to the switch component content description to improve accessibility support
- Enable adding overridden localisations to support translations that are not being returned from backend 