### PR TITLE
Fix empty consent list

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.0.1 - 2025-01-17
+### Fixed
+- Problem with displaying list of consents due to changes on Content Delivery Network.
+
 ## v3.0.0 - 2024-09-06
 - Release of a completely new version, built from scratch.
 

--- a/UI-SDK/build.gradle.kts
+++ b/UI-SDK/build.gradle.kts
@@ -76,7 +76,7 @@ dependencies {
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.navigation:navigation-compose:2.7.7")
 
-    implementation("com.cookieinformation:core:0.0.12")
+    implementation("com.cookieinformation:core:0.0.13")
 }
 
 publishing {
@@ -85,7 +85,7 @@ publishing {
         create<MavenPublication>("androidLib") {
             groupId = "com.cookieinformation"
             artifactId = "mobileconsents"
-            version = "3.0.0"
+            version = "3.0.1"
 
             afterEvaluate {
                 from(components["release"])


### PR DESCRIPTION
Fix the problem with displaying list of consents due to changes on Content Delivery Network.